### PR TITLE
removed between subject comparisons until we implement a proper statistical test for this comparison

### DIFF
--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -10,7 +10,7 @@ import pandas as pd
 from skbio import DistanceMatrix
 
 from ._utilities import (_get_group_pairs, _extract_distance_distribution,
-                         _between_subject_distance_distribution, _visualize,
+                         _visualize,
                          _get_pairwise_differences, _stats_and_visuals,
                          _add_metric_to_metadata, _linear_effects,
                          _regplot_subplots_from_dataframe, _load_metadata,
@@ -54,7 +54,7 @@ def pairwise_distances(output_dir: str, distance_matrix: DistanceMatrix,
                        state_column: str, state_1: str, state_2: str,
                        individual_id_column: str, parametric: bool=False,
                        palette: str='Set1', replicate_handling: str='error',
-                       between_group_distance: bool=False) -> None:
+                       ) -> None:
 
     _validate_input_values(state_1, state_2)
 
@@ -72,10 +72,6 @@ def pairwise_distances(output_dir: str, distance_matrix: DistanceMatrix,
             replicate_handling=replicate_handling)
         pairs[group] = _extract_distance_distribution(
             distance_matrix, group_pairs)
-        if between_group_distance:
-            between = group + '_between_subject'
-            pairs[between] = _between_subject_distance_distribution(
-                distance_matrix, group_pairs, metadata, group_column, group)
 
     # Calculate test statistics and generate boxplots
     _stats_and_visuals(

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -112,16 +112,10 @@ plugin.visualizers.register_function(
 plugin.visualizers.register_function(
     function=pairwise_distances,
     inputs={'distance_matrix': DistanceMatrix},
-    parameters={**paired_params,
-                'between_group_distance': Bool},
+    parameters={**paired_params},
     input_descriptions={'distance_matrix': (
         'Matrix of distances between pairs of samples.')},
-    parameter_descriptions={
-        **paired_parameter_descriptions,
-        'between_group_distance': (
-            'Whether to compare within-subject distances to distances between '
-            'all subjects that share the same metadata group_column.')
-    },
+    parameter_descriptions={**paired_parameter_descriptions},
     name='Paired pairwise distance testing and boxplots',
     description=(
         'Performs pairwise distance testing between sample pairs from each '
@@ -131,10 +125,7 @@ plugin.visualizers.register_function(
         'identical samples receiving different two different treatments. '
         'This action tests whether the pairwise distance between each subject '
         'pair differs between groups (e.g., groups of subjects receiving '
-        'different treatments) and optionally (if between_group_distance is '
-        'True) whether these within-subject distances are different from '
-        'distances between subjects that share the same metadata '
-        'group_column. Finally, produces boxplots of paired distance '
+        'different treatments) and produces boxplots of paired distance '
         'distributions for each group.')
 )
 


### PR DESCRIPTION
This is no longer an option for the `pairwise_distances` visualization. Will re-introduce in a later release, but we need to work out an appropriate statistical test for this. Not enough time before the 2017.8 release.

(tests like mann whitney and t-tests are inappropriate because they assume independence, but between-sample distances have multiple distances for each sample.)