### PR TITLE
replace print statements with warnings

### DIFF
--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -38,7 +38,7 @@ def pairwise_differences(output_dir: str, metadata: qiime2.Metadata,
     pairs_summary = pd.DataFrame()
     group_names = metadata[group_column].unique()
     for group in group_names:
-        group_pairs = _get_group_pairs(
+        group_pairs, errors = _get_group_pairs(
             metadata, group_value=group,
             individual_id_column=individual_id_column,
             group_column=group_column, state_column=state_column,
@@ -55,7 +55,7 @@ def pairwise_differences(output_dir: str, metadata: qiime2.Metadata,
 
     _stats_and_visuals(
         output_dir, pairs, y_label, group_column, state_column, state_1,
-        state_2, individual_id_column, parametric, palette,
+        state_2, individual_id_column, errors, parametric, palette,
         replicate_handling, multiple_group_test=True, pairwise_tests=True,
         paired_difference_tests=True, boxplot=True)
 
@@ -78,7 +78,7 @@ def pairwise_distances(output_dir: str, distance_matrix: DistanceMatrix,
     pairs_summary = pd.DataFrame()
     group_names = metadata[group_column].unique()
     for group in group_names:
-        group_pairs = _get_group_pairs(
+        group_pairs, errors = _get_group_pairs(
             metadata, group_value=group,
             individual_id_column=individual_id_column,
             group_column=group_column, state_column=state_column,
@@ -93,7 +93,7 @@ def pairwise_distances(output_dir: str, distance_matrix: DistanceMatrix,
     # Calculate test statistics and generate boxplots
     _stats_and_visuals(
         output_dir, pairs, 'distance', group_column,
-        state_column, state_1, state_2, individual_id_column,
+        state_column, state_1, state_2, individual_id_column, errors,
         parametric, palette, replicate_handling, multiple_group_test=True,
         pairwise_tests=True, paired_difference_tests=False, boxplot=True)
 

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -73,6 +73,7 @@ def _get_group_pairs(df, group_value, individual_id_column='SubjectID',
                      group_column='Group', state_column='time_point',
                      state_values=['1', '2'], replicate_handling='error'):
     results = []
+    errors = []
     group_members = df[group_column] == group_value
     group_md = df[group_members]
     for individual_id in set(group_md[individual_id_column]):
@@ -84,9 +85,11 @@ def _get_group_pairs(df, group_value, individual_id_column='SubjectID',
             _ind = df[individual_id_column] == individual_id
             individual_at_state_idx = group_md[_state & _ind].index
             if len(individual_at_state_idx) > 1:
-                print("Multiple values for {0} {1} at {2} {3} ({4})".format(
-                    individual_id_column, individual_id, state_column,
-                    state_value, ' '.join(map(str, individual_at_state_idx))))
+                errors.append(
+                    "Multiple values for {0} {1} at {2} {3} ({4})".format(
+                        individual_id_column, individual_id, state_column,
+                        state_value,
+                        ' '.join(map(str, individual_at_state_idx))))
                 if replicate_handling == 'error':
                     raise ValueError((
                         'Replicate values for individual {0} at state {1}. '
@@ -98,7 +101,7 @@ def _get_group_pairs(df, group_value, individual_id_column='SubjectID',
                 elif replicate_handling == 'drop':
                     pass
             elif len(individual_at_state_idx) == 0:
-                print("No values for {0} {1} at {2} {3}".format(
+                errors.append("No values for {0} {1} at {2} {3}".format(
                     individual_id_column, individual_id, state_column,
                     state_value))
                 pass
@@ -106,7 +109,7 @@ def _get_group_pairs(df, group_value, individual_id_column='SubjectID',
                 result.append(individual_at_state_idx[0])
         if len(result) == len(state_values):
             results.append(tuple(result))
-    return results
+    return results, errors
 
 
 def _extract_distance_distribution(distance_matrix: DistanceMatrix, pairs,
@@ -374,7 +377,7 @@ def _add_metric_to_metadata(table, metadata, metric):
 
 def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
                paired_difference_tests=False, plot=False, summary=False,
-               model_summary=False, model_results=False):
+               errors=False, model_summary=False, model_results=False):
 
     pd.set_option('display.max_colwidth', -1)
 
@@ -408,8 +411,12 @@ def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
         plot.savefig(join(output_dir, 'plot.pdf'), bbox_inches='tight')
         plt.close('all')
 
+    if errors is not False:
+        errors = '<br>'.join(errors)
+
     index = join(TEMPLATES, 'index.html')
     q2templates.render(index, output_dir, context={
+        'errors': errors,
         'summary': summary,
         'model_summary': model_summary,
         'model_results': model_results,
@@ -422,7 +429,7 @@ def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
 
 def _stats_and_visuals(output_dir, pairs, metric, group_column,
                        state_column, state_1, state_2,
-                       individual_id_column, parametric, palette,
+                       individual_id_column, errors, parametric, palette,
                        replicate_handling,
                        multiple_group_test=True, pairwise_tests=True,
                        paired_difference_tests=True, boxplot=True):
@@ -456,4 +463,5 @@ def _stats_and_visuals(output_dir, pairs, metric, group_column,
         name='Paired difference tests')
 
     _visualize(output_dir, multiple_group_test, pairwise_tests,
-               paired_difference_tests, boxplot, summary=summary)
+               paired_difference_tests, boxplot, summary=summary,
+               errors=errors)

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -411,9 +411,6 @@ def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
         plot.savefig(join(output_dir, 'plot.pdf'), bbox_inches='tight')
         plt.close('all')
 
-    if errors is not False:
-        errors = '<br>'.join(errors)
-
     index = join(TEMPLATES, 'index.html')
     q2templates.render(index, output_dir, context={
         'errors': errors,

--- a/q2_longitudinal/assets/index.html
+++ b/q2_longitudinal/assets/index.html
@@ -2,6 +2,25 @@
 
 {% block content %}
 
+{% if errors %}
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="accordion-heading">
+      <h4 class="panel-title">
+        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#table" aria-expanded="true" aria-controls="table">
+          WARNINGS (click here to collapse):
+        </a>
+      </h4>
+    </div>
+    <div id="table" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="accordion-heading">
+      <div class="alert alert-warning col-md-12">
+        <strong>{{ errors }}</strong>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 <div class="row">
   <div class="col-lg-12">
     {{ summary }}

--- a/q2_longitudinal/assets/index.html
+++ b/q2_longitudinal/assets/index.html
@@ -3,18 +3,20 @@
 {% block content %}
 
 {% if errors %}
-<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-  <div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="accordion-heading">
+<div class="panel-group" id="warnings" role="tablist" aria-multiselectable="true">
+  <div class="panel panel-warning">
+    <div class="panel-heading" role="tab" id="warnings-heading">
       <h4 class="panel-title">
-        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#table" aria-expanded="true" aria-controls="table">
-          WARNINGS (click here to collapse):
+        <a role="button" data-toggle="collapse" data-parent="#warnings" href="#warnings-list" aria-expanded="true" aria-controls="warnings-list">
+          Warnings (click here to collapse/expand):
         </a>
       </h4>
     </div>
-    <div id="table" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="accordion-heading">
+    <div id="warnings-list" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="warnings-heading">
       <div class="alert alert-warning col-md-12">
-        <strong>{{ errors }}</strong>
+        {% for error in errors %}
+        <p><strong>{{ error }}</strong></p>
+        {% endfor %}
       </div>
     </div>
   </div>

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -44,17 +44,17 @@ class longitudinalTestPluginBase(TestPluginBase):
 class UtilitiesTests(longitudinalTestPluginBase):
 
     def test_get_group_pairs(self):
-        res = _get_group_pairs(
+        res, err = _get_group_pairs(
             md, 'a', individual_id_column='ind', group_column='Group',
             state_column='Time', state_values=[1, 2],
             replicate_handling='drop')
         self.assertEqual(res, [('0', '3'), ('1', '4'), ('2', '5')])
-        res = _get_group_pairs(
+        res, err = _get_group_pairs(
             md_dup, 'a', individual_id_column='ind', group_column='Group',
             state_column='Time', state_values=[1, 2],
             replicate_handling='drop')
         self.assertEqual(res, [('0', '3')])
-        res = _get_group_pairs(
+        res, err = _get_group_pairs(
             md_dup, 'a', individual_id_column='ind', group_column='Group',
             state_column='Time', state_values=[1, 2],
             replicate_handling='random')


### PR DESCRIPTION
fixes #23 

Uses collapsible alert box, so that users can collapse very long warning messages and get on to the results. 

Thanks @thermokarst for discussing this behavior and directing me to the collapse widget!