### PR TITLE
ENH: Volatility Control Charts

### DIFF
--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -139,8 +139,8 @@ def linear_mixed_effects(output_dir: str, metadata: qiime2.Metadata,
 def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
                metric: str, state_column: str, individual_id_column: str,
                table: pd.DataFrame=None, palette: str='Set1', ci: int=95,
-               plot_control_limits=True
-               ) -> None:
+               plot_control_limits=True, method='fligner', center='median',
+               baseline=None) -> None:
 
     # find metric in metadata or derive from table and merge into metadata
     metadata = _add_metric_to_metadata(table, metadata, metric)
@@ -155,8 +155,8 @@ def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
 
     # compare variances
     variance_results = _per_group_variance_comparison(
-        metadata, metric, state_column, group_column, method='fligner',
-        center='median', baseline=None)
+        metadata, metric, state_column, group_column, method=method,
+        center=center, baseline=baseline)
 
     # summarize parameters and visualize
     summary = pd.Series(

--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -12,7 +12,7 @@ from skbio import DistanceMatrix
 from os.path import join
 
 from ._utilities import (_get_group_pairs, _extract_distance_distribution,
-                         _visualize, _per_group_variance_comparison,
+                         _visualize,
                          _get_pairwise_differences, _stats_and_visuals,
                          _add_metric_to_metadata, _linear_effects,
                          _regplot_subplots_from_dataframe, _load_metadata,
@@ -141,8 +141,7 @@ def linear_mixed_effects(output_dir: str, metadata: qiime2.Metadata,
 def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
                metric: str, state_column: str, individual_id_column: str,
                table: pd.DataFrame=None, palette: str='Set1', ci: int=95,
-               plot_control_limits=True, method='fligner', center='median',
-               baseline=None) -> None:
+               plot_control_limits=True) -> None:
 
     # find metric in metadata or derive from table and merge into metadata
     metadata = _add_metric_to_metadata(table, metadata, metric)
@@ -155,11 +154,6 @@ def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
         state_column, metric, metadata, group_column, ci=ci, palette=palette,
         plot_control_limits=plot_control_limits)
 
-    # compare variances
-    variance_results = _per_group_variance_comparison(
-        metadata, metric, state_column, group_column, method=method,
-        center=center, baseline=baseline)
-
     # summarize parameters and visualize
     summary = pd.Series(
         [metric, group_column, state_column, individual_id_column, global_mean,
@@ -169,6 +163,5 @@ def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
                'Global standard deviation'],
         name='Volatility test parameters')
 
-    _visualize(output_dir, pairwise_tests=variance_results, plot=chart,
-               summary=summary, plot_name='Control charts',
-               pairwise_test_name='Equality of variance tests')
+    _visualize(output_dir, plot=chart, summary=summary,
+               plot_name='Control charts')

--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -96,7 +96,8 @@ def pairwise_distances(output_dir: str, distance_matrix: DistanceMatrix,
         output_dir, pairs, 'distance', group_column,
         state_column, state_1, state_2, individual_id_column, errors,
         parametric, palette, replicate_handling, multiple_group_test=True,
-        pairwise_tests=True, paired_difference_tests=False, boxplot=True)
+        pairwise_tests=True, paired_difference_tests=False, boxplot=True,
+        plot_name='Pairwise distance boxplot')
 
 
 def linear_mixed_effects(output_dir: str, metadata: qiime2.Metadata,
@@ -133,7 +134,8 @@ def linear_mixed_effects(output_dir: str, metadata: qiime2.Metadata,
         name='Linear mixed effects parameters')
 
     _visualize(output_dir, model_summary=model_summary,
-               model_results=model_results, plot=g, summary=summary)
+               model_results=model_results, plot=g, summary=summary,
+               plot_name='Regression scatterplots')
 
 
 def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
@@ -168,4 +170,5 @@ def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
         name='Volatility test parameters')
 
     _visualize(output_dir, pairwise_tests=variance_results, plot=chart,
-               summary=summary)
+               summary=summary, plot_name='Control charts',
+               pairwise_test_name='Equality of variance tests')

--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -12,7 +12,7 @@ from skbio import DistanceMatrix
 from os.path import join
 
 from ._utilities import (_get_group_pairs, _extract_distance_distribution,
-                         _visualize,
+                         _visualize, _per_group_variance_comparison,
                          _get_pairwise_differences, _stats_and_visuals,
                          _add_metric_to_metadata, _linear_effects,
                          _regplot_subplots_from_dataframe, _load_metadata,
@@ -153,8 +153,10 @@ def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
         state_column, metric, metadata, group_column, ci=ci, palette=palette,
         plot_control_limits=plot_control_limits)
 
-    # backup
-    # chart, global_mean, global_std = _control_chart(state_column, metric, metadata, group_column, ci=ci, palette=palette, plot_control_limits=plot_control_limits)
+    # compare variances
+    variance_results = _per_group_variance_comparison(
+        metadata, metric, state_column, group_column, method='fligner',
+        center='median', baseline=None)
 
     # summarize parameters and visualize
     summary = pd.Series(
@@ -165,4 +167,5 @@ def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
                'Global standard deviation'],
         name='Volatility test parameters')
 
-    _visualize(output_dir, plot=chart, summary=summary)
+    _visualize(output_dir, pairwise_tests=variance_results, plot=chart,
+               summary=summary)

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -482,6 +482,7 @@ def _per_group_variance_comparison(metadata, metric, state_column,
 def _multiple_tests_correction(df, method='fdr_bh', sort=True):
     try:
         df['FDR P-value'] = multipletests(df['P-value'], method=method)[1]
+    # zero division error will occur if the P-value series is empty. Ignore.
     except ZeroDivisionError:
         pass
     if sort:

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -22,7 +22,7 @@ import numpy as np
 from skbio.stats.distance import MissingIDError
 from skbio import DistanceMatrix
 from scipy.stats import (kruskal, mannwhitneyu, wilcoxon, ttest_ind, ttest_rel,
-                         ttest_1samp, f_oneway)
+                         ttest_1samp, f_oneway, fligner, levene, bartlett)
 
 
 TEMPLATES = pkg_resources.resource_filename('q2_longitudinal', 'assets')
@@ -206,9 +206,7 @@ def _compare_pairwise_differences(groups, parametric=False):
         pvals.append((name, t, p))
     result = pd.DataFrame(pvals, columns=["Group", stat, "P-value"])
     result.set_index(["Group"], inplace=True)
-    result['FDR P-value'] = multipletests(
-        result['P-value'], method='fdr_bh')[1]
-    result.sort_index(inplace=True)
+    result = _multiple_tests_correction(result, method='fdr_bh')
     return result
 
 
@@ -268,12 +266,7 @@ def _per_method_pairwise_stats(groups, paired=False, parametric=True):
     result = pd.DataFrame(
         pvals, columns=["Group A", "Group B", stat_name, "P-value"])
     result.set_index(['Group A', 'Group B'], inplace=True)
-    try:
-        result['FDR P-value'] = multipletests(
-            result['P-value'], method='fdr_bh')[1]
-    except ZeroDivisionError:
-        pass
-    result.sort_index(inplace=True)
+    result = _multiple_tests_correction(result, method='fdr_bh')
 
     return result
 
@@ -405,6 +398,74 @@ def _calculate_variability(metadata, metric):
     lower_warning = global_mean - global_std * 2
     return (global_mean, global_std, upper_limit, lower_limit, upper_warning,
             lower_warning)
+
+
+def compare_variances(*groups, method='fligner', center='median'):
+    if method == 'fligner':
+        stat, pval = fligner(*groups, center=center)
+    elif method == 'levene':
+        stat, pval = levene(*groups, center=center)
+    elif method == 'bartlett':
+        stat, pval = bartlett(*groups)
+    return stat, pval
+
+
+def _per_group_variance_comparison(metadata, metric, state_column,
+                                   group_column, method='fligner',
+                                   center='median', baseline=None):
+    results = []
+    unique_states = metadata[state_column].unique()
+    unique_groups = metadata[group_column].unique()
+
+    # compare group variance across all timepoints
+    global_groups = [metadata[metadata[group_column] == group][metric]
+                     for group in unique_groups]
+    stat, pval = compare_variances(
+        *global_groups, method=method, center=center)
+    results.append(('All States', stat, pval))
+
+    # find baseline samples; assume baseline is first entry in unique states if
+    # not provided by user.
+    if baseline is None:
+        baseline = unique_states[0]
+
+    # compare group variance at each timepoint
+    groups = {
+        state: {group: metadata[(metadata[group_column] == group) &
+                                (metadata[state_column] == state)][metric]
+                for group in unique_groups} for state in unique_states}
+
+    for state in unique_states:
+        # compare to each other
+        stat, pval = compare_variances(
+            *groups[state].values(), method=method, center=center)
+        results.append((state, stat, pval))
+
+        # compare to baseline for that group
+        if state != baseline:
+            for group in unique_groups:
+                stat, pval = compare_variances(
+                    groups[baseline][group], groups[state][group],
+                    method=method, center=center)
+                comp_name = '{0}: {1} vs. {2}'.format(group, baseline, state)
+                results.append((comp_name, stat, pval))
+
+    # compile results and correct P values
+    result = pd.DataFrame(results, columns=["Comparison", method, "P-value"])
+    result.set_index(['Comparison'], inplace=True)
+    result = _multiple_tests_correction(result, method='fdr_bh', sort=False)
+
+    return result
+
+
+def _multiple_tests_correction(df, method='fdr_bh', sort=True):
+    try:
+        df['FDR P-value'] = multipletests(df['P-value'], method=method)[1]
+    except ZeroDivisionError:
+        pass
+    if sort:
+        df.sort_index(inplace=True)
+    return df
 
 
 def _control_chart(state_column, metric, metadata, group_by, ci=95,

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -350,7 +350,7 @@ def _regplot_subplots_from_dataframe(state_column, metric, metadata,
 
 
 def _control_chart_subplots(state_column, metric, metadata, group_column,
-                             ci=95, palette='Set1', plot_control_limits=True):
+                            ci=95, palette='Set1', plot_control_limits=True):
 
     groups = metadata[group_column].unique()
     chart, axes = plt.subplots(len(groups) + 1, figsize=(6, 18))

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -524,7 +524,9 @@ def _add_metric_to_metadata(table, metadata, metric):
 
 def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
                paired_difference_tests=False, plot=False, summary=False,
-               errors=False, model_summary=False, model_results=False):
+               errors=False, model_summary=False, model_results=False,
+               plot_name='Pairwise difference boxplot',
+               pairwise_test_name='Pairwise group comparison tests'):
 
     pd.set_option('display.max_colwidth', -1)
 
@@ -568,6 +570,8 @@ def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
         'pairwise_tests': pairwise_tests,
         'paired_difference_tests': paired_difference_tests,
         'plot': plot,
+        'plot_name': plot_name,
+        'pairwise_test_name': pairwise_test_name,
     })
 
 
@@ -576,7 +580,9 @@ def _stats_and_visuals(output_dir, pairs, metric, group_column,
                        individual_id_column, errors, parametric, palette,
                        replicate_handling,
                        multiple_group_test=True, pairwise_tests=True,
-                       paired_difference_tests=True, boxplot=True):
+                       paired_difference_tests=True, boxplot=True,
+                       plot_name='Pairwise difference boxplot',
+                       pairwise_test_name='Pairwise group comparison tests'):
     # kruskal test or ANOVA between groups
     if multiple_group_test:
         multiple_group_test = _multiple_group_difference(
@@ -608,4 +614,5 @@ def _stats_and_visuals(output_dir, pairs, metric, group_column,
 
     _visualize(output_dir, multiple_group_test, pairwise_tests,
                paired_difference_tests, boxplot, summary=summary,
-               errors=errors)
+               errors=errors, plot_name=plot_name,
+               pairwise_test_name=pairwise_test_name)

--- a/q2_longitudinal/assets/index.html
+++ b/q2_longitudinal/assets/index.html
@@ -27,14 +27,14 @@
   <div class="col-lg-12">
     {{ summary }}
     {% if plot %}
-    <h2>Pairwise difference boxplot</h1>
+    <h2>{{ plot_name }}</h1>
     <div class="text-center">
       <a href="plot.pdf">
         <img src="plot.png">
         <br>
         <p>Download as PDF</p>
       </a>
-      {% if pairwise_tests %}
+      {% if multiple_group_test %}
       <a href="pairs.tsv">
         <p>Download within-subject pairwise comparison data as tsv</p>
       </a>
@@ -79,7 +79,7 @@
     </div>
     {% endif %}
     {% if pairwise_tests %}
-    <h2>Pairwise group comparison tests</h1>
+    <h2>{{ pairwise_test_name }}</h1>
     <div class="col-lg-12">
       {{ pairwise_tests }}
       <a href="pairwise_tests.tsv">

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -7,8 +7,7 @@
 # ----------------------------------------------------------------------------
 
 
-from qiime2.plugin import (Str, Bool, Plugin, Metadata, Choices, Range, Float,
-                           Int)
+from qiime2.plugin import (Str, Bool, Plugin, Metadata, Choices, Range, Float)
 from q2_types.feature_table import FeatureTable, RelativeFrequency
 from ._longitudinal import (pairwise_differences, pairwise_distances,
                             linear_mixed_effects, volatility)
@@ -169,10 +168,7 @@ plugin.visualizers.register_function(
                 'metric': Str,
                 'group_column': Str,
                 'ci': Float % Range(0, 100),
-                'plot_control_limits': Bool,
-                'method': Str % Choices(['fligner', 'levene', 'bartlett']),
-                'center': Str % Choices(['median', 'mean', 'trimmed']),
-                'baseline': Int},
+                'plot_control_limits': Bool},
     input_descriptions={'table': (
         'Feature table to optionally use for paired comparisons.')},
     parameter_descriptions={
@@ -183,32 +179,9 @@ plugin.visualizers.register_function(
         'ci': 'Size of the confidence interval to plot on control chart.',
         'plot_control_limits': ('Plot global mean and control limits (2X and '
                                 '3X standard deviations).'),
-        'method': 'Statistic to test for equal variances.',
-        'center': ('Which function of the data to use in the test of equal '
-                   'variances.'),
-        'baseline': ('Which state to use as baseline for comparing variances. '
-                     'Must be a value in the metadata "state_column". By '
-                     'default will use the lowest value in "state_column".'),
     },
     name='Volatility analysis',
     description=(
-        'Plot control chart and compare longitudinal variance of a single '
-        'dependent variable, "metric". Variances are compared between each '
-        'group, as defined by the metadata column "group_column". Equality of '
-        'variances is tested between 1) all groups, regardless of state (time '
-        'point), 2) all groups at each individual state (time point), and 3) '
-        'between baseline and each state for each group. Choices of variance '
-        'tests include: 1) Bartlett\'s test, a parametric test, 2) Levene '
-        'test (which is recommended over Bartlett\'s test where there are '
-        'significant deviations from normality), and 3) Fligner-Killeen test, '
-        'which is a non-parametric test when populations are identical and '
-        'also recommended for its robustness. Each test tests the null '
-        'hypothesis that all input samples are from populations with equal '
-        'variances. Levene and Fligner tests support three different '
-        'centering methods: "median" is recommended for skewed (non-normal) '
-        'distributions; "mean" is recommended for symmetric, moderate-tailed '
-        'distributions; "trimmed" removes five percent of data points from '
-        'either end (to trim outliers) and is recommended for heavy-tailed '
-        'distributions. For more information on variance tests, see '
-        'docs.scipy.org/doc/scipy/reference/generated/scipy.stats.levene.html')
+        'Plot control chart of a single dependent variable, "metric", across '
+        'multiple groups contained in sample metadata column "group_column".')
 )

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -44,8 +44,7 @@ paired_params = {
     'state_1': Str,
     'state_2': Str,
     'parametric': Bool,
-    'replicate_handling': Str % Choices(
-        ['error', 'random', 'drop']),
+    'replicate_handling': Str % Choices(['error', 'random', 'drop']),
 }
 
 base_parameter_descriptions = {
@@ -169,7 +168,10 @@ plugin.visualizers.register_function(
                 'metric': Str,
                 'group_column': Str,
                 'ci': Float % Range(0, 100),
-                'plot_control_limits': Bool},
+                'plot_control_limits': Bool,
+                'method': Str % Choices(['fligner', 'levene', 'bartlett']),
+                'center': Str % Choices(['median', 'mean', 'trimmed']),
+                'baseline': Str},
     input_descriptions={'table': (
         'Feature table to optionally use for paired comparisons.')},
     parameter_descriptions={
@@ -179,11 +181,33 @@ plugin.visualizers.register_function(
             'Metadata column on which to separate groups for comparison'),
         'ci': 'Size of the confidence interval to plot on control chart.',
         'plot_control_limits': ('Plot global mean and control limits (2X and '
-                                '3X standard deviations).')
+                                '3X standard deviations).'),
+        'method': 'Statistic to test for equal variances.',
+        'center': ('Which function of the data to use in the test of equal '
+                   'variances.'),
+        'baseline': ('Which state to use as baseline for comparing variances. '
+                     'Must be a value in the metadata "state_column". By '
+                     'default will use the lowest value in "state_column".'),
     },
     name='Volatility analysis',
     description=(
         'Plot control chart and compare longitudinal variance of a single '
         'dependent variable, "metric". Variances are compared between each '
-        'group, as defined by the metadata column "group_column".')
+        'group, as defined by the metadata column "group_column". Equality of '
+        'variances is tested between 1) all groups, regardless of state (time '
+        'point), 2) all groups at each individual state (time point), and 3) '
+        'between baseline and each state for each group. Choices of variance '
+        'tests include: 1) Bartlett\'s test, a parametric test, 2) Levene '
+        'test (which is recommended over Bartlett\'s test where there are '
+        'significant deviations from normality), and 3) Fligner-Killeen test, '
+        'which is a non-parametric test when populations are identical and '
+        'also recommended for its robustness. Each test tests the null '
+        'hypothesis that all input samples are from populations with equal '
+        'variances. Levene and Fligner tests support three different '
+        'centering methods: "median" is recommended for skewed (non-normal) '
+        'distributions; "mean" is recommended for symmetric, moderate-tailed '
+        'distributions; "trimmed" removes five percent of data points from '
+        'either end (to trim outliers) and is recommended for heavy-tailed '
+        'distributions. For more information on variance tests, see '
+        'docs.scipy.org/doc/scipy/reference/generated/scipy.stats.levene.html')
 )

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -7,7 +7,8 @@
 # ----------------------------------------------------------------------------
 
 
-from qiime2.plugin import Str, Bool, Plugin, Metadata, Choices, Range, Float
+from qiime2.plugin import (Str, Bool, Plugin, Metadata, Choices, Range, Float,
+                           Int)
 from q2_types.feature_table import FeatureTable, RelativeFrequency
 from ._longitudinal import (pairwise_differences, pairwise_distances,
                             linear_mixed_effects, volatility)
@@ -171,7 +172,7 @@ plugin.visualizers.register_function(
                 'plot_control_limits': Bool,
                 'method': Str % Choices(['fligner', 'levene', 'bartlett']),
                 'center': Str % Choices(['median', 'mean', 'trimmed']),
-                'baseline': Str},
+                'baseline': Int},
     input_descriptions={'table': (
         'Feature table to optionally use for paired comparisons.')},
     parameter_descriptions={

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -10,7 +10,7 @@
 from qiime2.plugin import Str, Bool, Plugin, Metadata, Choices, Range, Float
 from q2_types.feature_table import FeatureTable, RelativeFrequency
 from ._longitudinal import (pairwise_differences, pairwise_distances,
-                            linear_mixed_effects)
+                            linear_mixed_effects, volatility)
 import q2_longitudinal
 from q2_types.distance_matrix import DistanceMatrix
 
@@ -159,4 +159,31 @@ plugin.visualizers.register_function(
         '"metric". Perform LME and plot line plots of each group column. A '
         'feature table artifact is required input, though whether "metric" is '
         'derived from the feature table or metadata is optional.')
+)
+
+
+plugin.visualizers.register_function(
+    function=volatility,
+    inputs={'table': FeatureTable[RelativeFrequency]},
+    parameters={**base_parameters,
+                'metric': Str,
+                'group_column': Str,
+                'ci': Float % Range(0, 100),
+                'plot_control_limits': Bool},
+    input_descriptions={'table': (
+        'Feature table to optionally use for paired comparisons.')},
+    parameter_descriptions={
+        **base_parameter_descriptions,
+        'metric': 'Numerical metadata or artifact column to test.',
+        'group_column': (
+            'Metadata column on which to separate groups for comparison'),
+        'ci': 'Size of the confidence interval to plot on control chart.',
+        'plot_control_limits': ('Plot global mean and control limits (2X and '
+                                '3X standard deviations).')
+    },
+    name='Volatility analysis',
+    description=(
+        'Plot control chart and compare longitudinal variance of a single '
+        'dependent variable, "metric". Variances are compared between each '
+        'group, as defined by the metadata column "group_column".')
 )

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -149,22 +149,25 @@ class UtilitiesTests(longitudinalTestPluginBase):
         self.assertEqual(
             list(test_df['FDR P-value']), [1., 1., 0.030000000000000002])
 
+    def test_multiple_tests_correction_zerodivisionerror(self):
+        test_df = pd.DataFrame(
+            pd.DataFrame({'Group': [], 'P-value': []}))
+        test_df_mt = _multiple_tests_correction(test_df)
+        # ZeroDivisionError is ignored, so new df should be empty and == old
+        self.assertEqual(test_df_mt.sort_index(inplace=True),
+                         test_df.sort_index(inplace=True))
+
     def test_per_group_variance_comparison(self):
-        exp = pd.DataFrame(
-            [(12, 7.729282, 0.005433, 0.027166),
-             (6, 0.163122, .686298, 0.726866),
-             (6, 0.122009, 0.726866, 0.726866),
-             (6, 0.635881, 0.425206, 0.708677),
-             (6, 0.996229, 0.318225, 0.708677)],
-            columns=['N', 'fligner test statistic', 'P-Value', 'FDR P-value'],
-            index=['All states: compare groups', 'State 1: compare groups',
-                   'State 2: compare groups', 'a: 1 vs. 2', 'b: 1 vs. 2'])
-        exp.index.name = 'Comparison'
         result = _per_group_variance_comparison(
             md, 'Value', 'Time', 'Group')
         self.assertAlmostEqual(
-            result.sort_index(inplace=True), exp.sort_index(inplace=True))
+            result.sort_index(inplace=True), exp_vol.sort_index(inplace=True))
 
+    def test_per_group_variance_comparison_non_default_baseline(self):
+        result = _per_group_variance_comparison(
+            md, 'Value', 'Time', 'Group', baseline=2)
+        self.assertAlmostEqual(
+            result.sort_index(inplace=True), exp_vol.sort_index(inplace=True))
 
 # This test class really just makes sure that each plugin runs without error.
 # UtilitiesTests handles all stats under the hood, so here we just want to make
@@ -297,3 +300,14 @@ dm = DistanceMatrix.read(StringIO(
 
 groups = {'a': [1, 2, 3, 2, 3, 1.5, 2.5, 2.7, 3, 2, 1, 1.5],
           'b': [3, 4, 5, 4.3, 3.4, 3.2, 3, 4.3, 4.9, 5, 3.2, 3.6]}
+
+exp_vol = pd.DataFrame(
+    [(12, 7.729282, 0.005433, 0.027166),
+     (6, 0.163122, .686298, 0.726866),
+     (6, 0.122009, 0.726866, 0.726866),
+     (6, 0.635881, 0.425206, 0.708677),
+     (6, 0.996229, 0.318225, 0.708677)],
+    columns=['N', 'fligner test statistic', 'P-Value', 'FDR P-value'],
+    index=['All states: compare groups', 'State 1: compare groups',
+           'State 2: compare groups', 'a: 1 vs. 2', 'b: 1 vs. 2'])
+exp_vol.index.name = 'Comparison'

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -125,14 +125,15 @@ class UtilitiesTests(longitudinalTestPluginBase):
     def test_compare_variances_equal_variance(self):
         for method, exp in zip(['fligner', 'levene', 'bartlett'], [1, 1, 1]):
             groups = [[1, 2, 3], [4, 5, 6]]
-            s, p = compare_variances(*groups, method=method)
+            s, p, c = compare_variances(*groups, method=method)
             self.assertAlmostEqual(p, exp)
+            self.assertEqual(c, 6)
 
     def test_compare_variances_unequal_variance(self):
         for method, exp in zip(['fligner', 'levene', 'bartlett'],
                                [0.2984133, 0.3024691, 0.00131798]):
             groups = [[1, 2, 3], [4, 15, 96]]
-            s, p = compare_variances(*groups, method=method)
+            s, p, c = compare_variances(*groups, method=method)
             self.assertAlmostEqual(p, exp)
 
 

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -15,9 +15,10 @@ from q2_longitudinal._utilities import (
     _get_group_pairs, _extract_distance_distribution,
     _get_pairwise_differences, _validate_input_values, _validate_input_columns,
     _between_subject_distance_distribution, _compare_pairwise_differences,
-    _multiple_group_difference, _per_method_pairwise_stats)
+    _multiple_group_difference, _per_method_pairwise_stats,
+    _calculate_variability)
 from q2_longitudinal._longitudinal import (
-    pairwise_differences, pairwise_distances, linear_mixed_effects)
+    pairwise_differences, pairwise_distances, linear_mixed_effects, volatility)
 import tempfile
 import pkg_resources
 from qiime2.plugin.testing import TestPluginBase
@@ -115,6 +116,12 @@ class UtilitiesTests(longitudinalTestPluginBase):
         res = _per_method_pairwise_stats(groups, paired=True, parametric=False)
         self.assertAlmostEqual(res['FDR P-value'][0], 0.0021830447373622506)
 
+    def test_calculate_variability(self):
+        res = _calculate_variability(md, 'Value')
+        for obs, exp in zip(res, [0.1808333, 0.0634548, 0.3711978, -0.0095311,
+                                  0.30774299, 0.05392367]):
+            self.assertAlmostEqual(obs, exp)
+
 
 # This test class really just makes sure that each plugin runs without error.
 # UtilitiesTests handles all stats under the hood, so here we just want to make
@@ -204,6 +211,12 @@ class longitudinalTests(longitudinalTestPluginBase):
             group_categories='delivery,diet,antiexposedall',
             individual_id_column='studyid',
             metric='e2c3ff4f647112723741aa72087f1bfa')
+
+    def test_volatility(self):
+        volatility(
+            output_dir=self.temp_dir.name, metadata=self.md_ecam_fp,
+            metric='observed_otus', group_column='delivery',
+            state_column='month', individual_id_column='studyid')
 
 
 md = pd.DataFrame([(1, 'a', 0.11, 1), (1, 'a', 0.12, 2), (1, 'a', 0.13, 3),

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -16,7 +16,7 @@ from q2_longitudinal._utilities import (
     _get_pairwise_differences, _validate_input_values, _validate_input_columns,
     _between_subject_distance_distribution, _compare_pairwise_differences,
     _multiple_group_difference, _per_method_pairwise_stats,
-    _calculate_variability)
+    _calculate_variability, compare_variances)
 from q2_longitudinal._longitudinal import (
     pairwise_differences, pairwise_distances, linear_mixed_effects, volatility)
 import tempfile
@@ -121,6 +121,19 @@ class UtilitiesTests(longitudinalTestPluginBase):
         for obs, exp in zip(res, [0.1808333, 0.0634548, 0.3711978, -0.0095311,
                                   0.30774299, 0.05392367]):
             self.assertAlmostEqual(obs, exp)
+
+    def test_compare_variances_equal_variance(self):
+        for method, exp in zip(['fligner', 'levene', 'bartlett'], [1, 1, 1]):
+            groups = [[1, 2, 3], [4, 5, 6]]
+            s, p = compare_variances(*groups, method=method)
+            self.assertAlmostEqual(p, exp)
+
+    def test_compare_variances_unequal_variance(self):
+        for method, exp in zip(['fligner', 'levene', 'bartlett'],
+                               [0.2984133, 0.3024691, 0.00131798]):
+            groups = [[1, 2, 3], [4, 15, 96]]
+            s, p = compare_variances(*groups, method=method)
+            self.assertAlmostEqual(p, exp)
 
 
 # This test class really just makes sure that each plugin runs without error.

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -16,7 +16,8 @@ from q2_longitudinal._utilities import (
     _get_pairwise_differences, _validate_input_values, _validate_input_columns,
     _between_subject_distance_distribution, _compare_pairwise_differences,
     _multiple_group_difference, _per_method_pairwise_stats,
-    _calculate_variability, compare_variances)
+    _calculate_variability, compare_variances, _multiple_tests_correction,
+    _add_sample_size_to_xtick_labels, _per_group_variance_comparison)
 from q2_longitudinal._longitudinal import (
     pairwise_differences, pairwise_distances, linear_mixed_effects, volatility)
 import tempfile
@@ -135,6 +136,34 @@ class UtilitiesTests(longitudinalTestPluginBase):
             groups = [[1, 2, 3], [4, 15, 96]]
             s, p, c = compare_variances(*groups, method=method)
             self.assertAlmostEqual(p, exp)
+
+    def test_add_sample_size_to_xtick_labels(self):
+        groups = {'a': [1, 2, 3], 'b': [1, 2], 'c': [1, 2, 3]}
+        labels = _add_sample_size_to_xtick_labels(groups)
+        self.assertEqual(labels, ['a (n=3)', 'b (n=2)', 'c (n=3)'])
+
+    def test_multiple_tests_correction(self):
+        test_df = pd.DataFrame(
+            pd.DataFrame({'Group': [1, 2, 3], 'P-value': [1, 1, 0.01]}))
+        test_df = _multiple_tests_correction(test_df)
+        self.assertEqual(
+            list(test_df['FDR P-value']), [1., 1., 0.030000000000000002])
+
+    def test_per_group_variance_comparison(self):
+        exp = pd.DataFrame(
+            [(12, 7.729282, 0.005433, 0.027166),
+             (6, 0.163122, .686298, 0.726866),
+             (6, 0.122009, 0.726866, 0.726866),
+             (6, 0.635881, 0.425206, 0.708677),
+             (6, 0.996229, 0.318225, 0.708677)],
+            columns=['N', 'fligner test statistic', 'P-Value', 'FDR P-value'],
+            index=['All states: compare groups', 'State 1: compare groups',
+                   'State 2: compare groups', 'a: 1 vs. 2', 'b: 1 vs. 2'])
+        exp.index.name = 'Comparison'
+        result = _per_group_variance_comparison(
+            md, 'Value', 'Time', 'Group')
+        self.assertAlmostEqual(
+            result.sort_index(inplace=True), exp.sort_index(inplace=True))
 
 
 # This test class really just makes sure that each plugin runs without error.

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -16,8 +16,8 @@ from q2_longitudinal._utilities import (
     _get_pairwise_differences, _validate_input_values, _validate_input_columns,
     _between_subject_distance_distribution, _compare_pairwise_differences,
     _multiple_group_difference, _per_method_pairwise_stats,
-    _calculate_variability, compare_variances, _multiple_tests_correction,
-    _add_sample_size_to_xtick_labels, _per_group_variance_comparison)
+    _calculate_variability, _multiple_tests_correction,
+    _add_sample_size_to_xtick_labels)
 from q2_longitudinal._longitudinal import (
     pairwise_differences, pairwise_distances, linear_mixed_effects, volatility)
 import tempfile
@@ -123,20 +123,6 @@ class UtilitiesTests(longitudinalTestPluginBase):
                                   0.30774299, 0.05392367]):
             self.assertAlmostEqual(obs, exp)
 
-    def test_compare_variances_equal_variance(self):
-        for method, exp in zip(['fligner', 'levene', 'bartlett'], [1, 1, 1]):
-            groups = [[1, 2, 3], [4, 5, 6]]
-            s, p, c = compare_variances(*groups, method=method)
-            self.assertAlmostEqual(p, exp)
-            self.assertEqual(c, 6)
-
-    def test_compare_variances_unequal_variance(self):
-        for method, exp in zip(['fligner', 'levene', 'bartlett'],
-                               [0.2984133, 0.3024691, 0.00131798]):
-            groups = [[1, 2, 3], [4, 15, 96]]
-            s, p, c = compare_variances(*groups, method=method)
-            self.assertAlmostEqual(p, exp)
-
     def test_add_sample_size_to_xtick_labels(self):
         groups = {'a': [1, 2, 3], 'b': [1, 2], 'c': [1, 2, 3]}
         labels = _add_sample_size_to_xtick_labels(groups)
@@ -156,18 +142,6 @@ class UtilitiesTests(longitudinalTestPluginBase):
         # ZeroDivisionError is ignored, so new df should be empty and == old
         self.assertEqual(test_df_mt.sort_index(inplace=True),
                          test_df.sort_index(inplace=True))
-
-    def test_per_group_variance_comparison(self):
-        result = _per_group_variance_comparison(
-            md, 'Value', 'Time', 'Group')
-        self.assertAlmostEqual(
-            result.sort_index(inplace=True), exp_vol.sort_index(inplace=True))
-
-    def test_per_group_variance_comparison_non_default_baseline(self):
-        result = _per_group_variance_comparison(
-            md, 'Value', 'Time', 'Group', baseline=2)
-        self.assertAlmostEqual(
-            result.sort_index(inplace=True), exp_vol.sort_index(inplace=True))
 
 
 # This test class really just makes sure that each plugin runs without error.

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -169,6 +169,7 @@ class UtilitiesTests(longitudinalTestPluginBase):
         self.assertAlmostEqual(
             result.sort_index(inplace=True), exp_vol.sort_index(inplace=True))
 
+
 # This test class really just makes sure that each plugin runs without error.
 # UtilitiesTests handles all stats under the hood, so here we just want to make
 # sure all plugins run smoothly.


### PR DESCRIPTION
fixes #35 

Well, it's a partial fix to #32, ~~but enough to close that issue~~. I added control charts, ~~but instead of using the qiime1 volatility analysis I use tests for equality of variance to examine volatility and data spread across time~~. LME, already in `q2-longitudinal`, appears to be a better way to examine differences in longitudinal trajectory than the qiime1 volatility methods. So I don't plan to implement the qiime1 methods ~~and we can close#32~~. 

**UPDATE 9/15/17:** the variance tests that I previously added assume sample independence, so are only appropriate for group comparisons at individual timepoints, not comparisons across time (which are the more important/interesting analysis). Hence we will only generate control charts for now, pending better stats. Still don't want to use the qiime1 volatility analyses, but will keep open that issue and document progress on the stats.