### PR TITLE
BUG: linear-mixed-effects failed when one variable was provided as input

### DIFF
--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -344,15 +344,20 @@ def _regplot_subplots_from_dataframe(state_column, metric, metadata,
                                      group_by, lowess=False, ci=95,
                                      palette='Set1'):
     '''plot a single regplot for each group in group_by.'''
-    f, axes = plt.subplots(len(group_by), figsize=(6, 18))
+    height = 6 * len(group_by)
+    f, axes = plt.subplots(len(group_by), figsize=(6, height))
     for num in range(len(group_by)):
+        if len(group_by) > 1:
+            ax = axes[num]
+        else:
+            ax = axes
         sns.set_palette(palette)
         for group in metadata[group_by[num]].unique():
             subset = metadata[metadata[group_by[num]] == group]
             sns.regplot(state_column, metric, data=subset, fit_reg=True,
                         scatter_kws={"marker": ".", "s": 100}, label=group,
-                        ax=axes[num], lowess=lowess, ci=ci)
-        axes[num].legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
+                        ax=ax, lowess=lowess, ci=ci)
+        ax.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
     return f
 
 

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -344,10 +344,11 @@ def _regplot_subplots_from_dataframe(state_column, metric, metadata,
                                      group_by, lowess=False, ci=95,
                                      palette='Set1'):
     '''plot a single regplot for each group in group_by.'''
-    height = 6 * len(group_by)
-    f, axes = plt.subplots(len(group_by), figsize=(6, height))
-    for num in range(len(group_by)):
-        if len(group_by) > 1:
+    num_groups = len(group_by)
+    height = 6 * num_groups
+    f, axes = plt.subplots(num_groups, figsize=(6, height))
+    for num in range(num_groups):
+        if num_groups > 1:
             ax = axes[num]
         else:
             ax = axes

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -197,6 +197,13 @@ class longitudinalTests(longitudinalTestPluginBase):
             group_categories='delivery,diet,antiexposedall',
             individual_id_column='studyid', metric='observed_otus')
 
+    def test_linear_mixed_effects_one_variable(self):
+        linear_mixed_effects(
+            output_dir=self.temp_dir.name, table=None,
+            metadata=self.md_ecam_fp, state_column='month',
+            group_categories='delivery',
+            individual_id_column='studyid', metric='observed_otus')
+
     def test_linear_mixed_effects_taxa(self):
         linear_mixed_effects(
             output_dir=self.temp_dir.name, table=self.table_ecam_fp,


### PR DESCRIPTION
fixes #38 

Fixed LME plotting function bug that caused failure when one variable is provided as input.

For whatever reason, `matplotlib.pyplot.subplots` returns `axes` as an array if `nrows` > 1, but as a single ax object if `nrows` = 1. I'm sure there must be a very good reason for this, but it threw me off, leading to this bug.

Also added a unit test to ensure that a single variable allows LME to run without failure.