### PR TITLE
LME fails gracefully when singular matrix error is raised

### DIFF
--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -297,11 +297,11 @@ def _linear_effects(metadata, metric, state_column, group_categories,
     try:
         model_fit = mlm.fit()
     except LinAlgError:
-        raise ValueError((
+        raise ValueError(
             'Linear model will not compute due to singular matrix error. '
             'This may occur if input variables correlate closely or exhibit '
             'zero variance. Please check your input variables. Removing '
-            'potential covariates may resolve this issue.'))
+            'potential covariates may resolve this issue.')
 
     # summarize model and format prettily
     model_summary, model_results = model_fit.summary().tables

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -246,6 +246,14 @@ class longitudinalTests(longitudinalTestPluginBase):
             metric='observed_otus', group_column='delivery',
             state_column='month', individual_id_column='studyid')
 
+    def test_linear_mixed_effects_singular_matrix_error(self):
+        with self.assertRaisesRegex(ValueError, "singular matrix error"):
+            linear_mixed_effects(
+                output_dir=self.temp_dir.name, table=None,
+                metadata=self.md_ecam_fp, state_column='month',
+                group_categories='diet,diet_3',
+                individual_id_column='studyid', metric='observed_otus')
+
 
 md = pd.DataFrame([(1, 'a', 0.11, 1), (1, 'a', 0.12, 2), (1, 'a', 0.13, 3),
                    (2, 'a', 0.19, 1), (2, 'a', 0.18, 2), (2, 'a', 0.21, 3),


### PR DESCRIPTION
fixes #39 

Now raises an informative error when singular linkage matrix error occurs.

I have confirmed that this error certainly occurs when exact covariates are passed as input.

I had added a unit test to confirm that error message is raised when exact covariates are input.