### PR TITLE
ENH: added raw data download to visualizers

### DIFF
--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -133,8 +133,12 @@ def linear_mixed_effects(output_dir: str, metadata: qiime2.Metadata,
                'Individual ID column'],
         name='Linear mixed effects parameters')
 
+    raw_data = metadata[[
+        metric, state_column, individual_id_column, *group_categories]]
+
     _visualize(output_dir, model_summary=model_summary,
                model_results=model_results, plot=g, summary=summary,
+               raw_data=raw_data,
                plot_name='Regression scatterplots')
 
 
@@ -163,5 +167,8 @@ def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
                'Global standard deviation'],
         name='Volatility test parameters')
 
-    _visualize(output_dir, plot=chart, summary=summary,
+    raw_data = metadata[[
+        metric, state_column, individual_id_column, group_column]]
+
+    _visualize(output_dir, plot=chart, summary=summary, raw_data=raw_data,
                plot_name='Control charts')

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -471,7 +471,7 @@ def _add_metric_to_metadata(table, metadata, metric):
 def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
                paired_difference_tests=False, plot=False, summary=False,
                errors=False, model_summary=False, model_results=False,
-               plot_name='Pairwise difference boxplot',
+               raw_data=False, plot_name='Pairwise difference boxplot',
                pairwise_test_name='Pairwise group comparison tests'):
 
     pd.set_option('display.max_colwidth', -1)
@@ -486,6 +486,10 @@ def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
     if pairwise_tests is not False:
         pairwise_tests.to_csv(join(output_dir, 'pairwise_tests.tsv'), sep='\t')
         pairwise_tests = q2templates.df_to_html(pairwise_tests)
+
+    if raw_data is not False:
+        raw_data.to_csv(join(output_dir, 'raw-data.tsv'), sep='\t')
+        raw_data = True
 
     if paired_difference_tests is not False:
         paired_difference_tests.to_csv(join(
@@ -517,6 +521,7 @@ def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
         'paired_difference_tests': paired_difference_tests,
         'plot': plot,
         'plot_name': plot_name,
+        'raw_data': raw_data,
         'pairwise_test_name': pairwise_test_name,
     })
 

--- a/q2_longitudinal/assets/index.html
+++ b/q2_longitudinal/assets/index.html
@@ -34,6 +34,11 @@
         <br>
         <p>Download as PDF</p>
       </a>
+      {% if raw_data %}
+      <a href="raw-data.tsv">
+        <p>Download raw data as tsv</p>
+      </a>
+      {% endif %}
       {% if multiple_group_test %}
       <a href="pairs.tsv">
         <p>Download within-subject pairwise comparison data as tsv</p>


### PR DESCRIPTION
fixes #47 

raw data download already existed for `pairwise-differences` and `pairwise-distances`; this has been added for `linear-mixed-effects` and `volatility`.