### PR TITLE
spaghetti plots enabled

### DIFF
--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -145,7 +145,8 @@ def linear_mixed_effects(output_dir: str, metadata: qiime2.Metadata,
 def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
                metric: str, state_column: str, individual_id_column: str,
                table: pd.DataFrame=None, palette: str='Set1', ci: int=95,
-               plot_control_limits=True, xtick_interval=None) -> None:
+               plot_control_limits=True, xtick_interval=None, yscale='linear',
+               spaghetti=False) -> None:
 
     # find metric in metadata or derive from table and merge into metadata
     metadata = _add_metric_to_metadata(table, metadata, metric)
@@ -155,8 +156,9 @@ def volatility(output_dir: str, metadata: qiime2.Metadata, group_column: str,
 
     # plot control charts
     chart, global_mean, global_std = _control_chart_subplots(
-        state_column, metric, metadata, group_column, ci=ci, palette=palette,
-        plot_control_limits=plot_control_limits, xtick_interval=xtick_interval)
+        state_column, metric, metadata, group_column, individual_id_column,
+        ci=ci, palette=palette, plot_control_limits=plot_control_limits,
+        xtick_interval=xtick_interval, yscale=yscale, spaghetti=spaghetti)
 
     # summarize parameters and visualize
     summary = pd.Series(

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -180,6 +180,8 @@ plugin.visualizers.register_function(
                 'group_column': Str,
                 'ci': Float % Range(0, 100),
                 'plot_control_limits': Bool,
+                'yscale': Str % Choices(["linear", "log", "symlog", "logit"]),
+                'spaghetti': Bool,
                 'xtick_interval': Int},
     input_descriptions={'table': (
         'Feature table to optionally use for paired comparisons.')},
@@ -191,6 +193,8 @@ plugin.visualizers.register_function(
         'ci': 'Size of the confidence interval to plot on control chart.',
         'plot_control_limits': ('Plot global mean and control limits (2X and '
                                 '3X standard deviations).'),
+        'yscale': 'y-axis scaling strategy to apply.',
+        'spaghetti': 'Co-plot spaghetti plot of per-individual trajectories.',
         'xtick_interval': ('Interval between major tick marks on x axis. '
                            'Defaults to 1, or autoscales to show up to 30 '
                            'ticks if data contain more than 30 x-axis values.')


### PR DESCRIPTION
fixes #51 

supports optional spaghetti plotting, i.e., plot vectors for each individual subject. Looks like this (faded lines are individual vectors, solid lines are what you see with spaghetti disabled):
![image](https://user-images.githubusercontent.com/1907564/31345005-0044f398-acda-11e7-9eb8-3309d159f96b.png)
