### PR TITLE
added static distance/difference computation and tests

### DIFF
--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -209,7 +209,7 @@ def nmit(table: pd.DataFrame, metadata: qiime2.Metadata,
 
 def first_differences(metadata: qiime2.Metadata, state_column: str,
                       individual_id_column: str, metric: str,
-                      replicate_handling: str='error',
+                      replicate_handling: str='error', baseline: str=None,
                       table: pd.DataFrame=None) -> pd.Series:
 
     # find metric in metadata or derive from table and merge into metadata
@@ -226,12 +226,12 @@ def first_differences(metadata: qiime2.Metadata, state_column: str,
 
     return _first_differences(
         metadata, state_column, individual_id_column, metric,
-        replicate_handling, distance_matrix=None)
+        replicate_handling, baseline=baseline, distance_matrix=None)
 
 
 def first_distances(distance_matrix: skbio.DistanceMatrix,
                     metadata: qiime2.Metadata, state_column: str,
-                    individual_id_column: str,
+                    individual_id_column: str, baseline: str=None,
                     replicate_handling: str='error') -> pd.Series:
 
     # load and validate metadata
@@ -246,4 +246,5 @@ def first_distances(distance_matrix: skbio.DistanceMatrix,
 
     return _first_differences(
         metadata, state_column, individual_id_column, metric=None,
-        replicate_handling=replicate_handling, distance_matrix=distance_matrix)
+        replicate_handling=replicate_handling, baseline=baseline,
+        distance_matrix=distance_matrix)

--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -209,7 +209,7 @@ def nmit(table: pd.DataFrame, metadata: qiime2.Metadata,
 
 def first_differences(metadata: qiime2.Metadata, state_column: str,
                       individual_id_column: str, metric: str,
-                      replicate_handling: str='error', baseline: str=None,
+                      replicate_handling: str='error', baseline: float=None,
                       table: pd.DataFrame=None) -> pd.Series:
 
     # find metric in metadata or derive from table and merge into metadata
@@ -231,7 +231,7 @@ def first_differences(metadata: qiime2.Metadata, state_column: str,
 
 def first_distances(distance_matrix: skbio.DistanceMatrix,
                     metadata: qiime2.Metadata, state_column: str,
-                    individual_id_column: str, baseline: str=None,
+                    individual_id_column: str, baseline: float=None,
                     replicate_handling: str='error') -> pd.Series:
 
     # load and validate metadata

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -732,6 +732,8 @@ def _first_differences(metadata, state_column, individual_id_column, metric,
 
     # if calculating static differences, validate baseline as a valid state
     if baseline is not None:
+        # cast baseline to same type as states
+        baseline = metadata[state_column].dtype.type(baseline)
         # validate baseline state
         if baseline not in states:
             raise ValueError(

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -267,12 +267,13 @@ plugin.methods.register_function(
         **shared_parameter_descriptions,
         'metric': 'Numerical metadata or artifact column to test.',
         'baseline': (
-            'Toggle calculation of static differences instead of first '
-            'differences. If a "baseline" value is provided, sample '
-            'differences at each state are compared against the baseline '
-            'state, instead of the previous state. Must be a value listed in '
-            'the state_column that designates a baseline state against which '
-            'all other states should be compared.')
+            'A value listed in the state_column metadata column against which '
+            'all other states should be compared. Toggles calculation of '
+            'static differences instead of first differences (which are '
+            'calculated if no value is given for baseline). If a "baseline" '
+            'value is provided, sample differences at each state are compared '
+            'against the baseline state, instead of the previous state. Must '
+            'be a value listed in the state_column.')
     },
     output_descriptions={'first_differences': 'Series of first differences.'},
     name=('Compute first differences or difference from baseline between '
@@ -299,7 +300,7 @@ plugin.methods.register_function(
     inputs={'distance_matrix': DistanceMatrix},
     parameters={**miscellaneous_parameters,
                 **shared_parameters,
-                'baseline': Str},
+                'baseline': Float},
     outputs=[('first_distances', SampleData[FirstDifferences])],
     input_descriptions={
         'distance_matrix': 'Matrix of distances between pairs of samples.'},
@@ -307,12 +308,13 @@ plugin.methods.register_function(
         **miscellaneous_parameter_descriptions,
         **shared_parameter_descriptions,
         'baseline': (
-            'Toggle calculation of static distances instead of first '
-            'distances. If a "baseline" value is provided, sample '
-            'distances at each state are compared against the baseline '
-            'state, instead of the previous state. Must be a value listed in '
-            'the state_column that designates a baseline state against which '
-            'all other states should be compared.')
+            'A value listed in the state_column metadata column against which '
+            'all other states should be compared. Toggles calculation of '
+            'static distances instead of first distances (which are '
+            'calculated if no value is given for baseline). If a "baseline" '
+            'value is provided, sample distances at each state are compared '
+            'against the baseline state, instead of the previous state. Must '
+            'be a value listed in the state_column.')
     },
     output_descriptions={'first_distances': 'Series of first distances.'},
     name=('Compute first distances or distance from baseline between '

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -256,7 +256,8 @@ plugin.methods.register_function(
     inputs={'table': FeatureTable[RelativeFrequency]},
     parameters={**miscellaneous_parameters,
                 **shared_parameters,
-                'metric': Str},
+                'metric': Str,
+                'baseline': Str},
     outputs=[('first_differences', SampleData[FirstDifferences])],
     input_descriptions={
         'table': ('Feature table to optionally use for computing first '
@@ -265,9 +266,17 @@ plugin.methods.register_function(
         **miscellaneous_parameter_descriptions,
         **shared_parameter_descriptions,
         'metric': 'Numerical metadata or artifact column to test.',
+        'baseline': (
+            'Toggle calculation of static differences instead of first '
+            'differences. If a "baseline" value is provided, sample '
+            'differences at each state are compared against the baseline '
+            'state, instead of the previous state. Must be a value listed in '
+            'the state_column that designates a baseline state against which '
+            'all other states should be compared.')
     },
     output_descriptions={'first_differences': 'Series of first differences.'},
-    name='First difference computation between sequential states',
+    name=('Compute first differences or difference from baseline between '
+          'sequential states'),
     description=(
         'Calculates first differences in "metric" between sequential states '
         'for samples collected from individual subjects sampled repeatedly at '
@@ -280,7 +289,8 @@ plugin.methods.register_function(
         'labeled by the SampleIDs at time 1). This file can be used as input '
         'to linear mixed effects models or other longitudinal or diversity '
         'methods to compare changes in first differences across time or among '
-        'groups of subjects.')
+        'groups of subjects. Also supports differences from baseline (or '
+        'other static comparison state) by setting the "baseline" parameter.')
 )
 
 
@@ -288,16 +298,25 @@ plugin.methods.register_function(
     function=first_distances,
     inputs={'distance_matrix': DistanceMatrix},
     parameters={**miscellaneous_parameters,
-                **shared_parameters},
+                **shared_parameters,
+                'baseline': Str},
     outputs=[('first_distances', SampleData[FirstDifferences])],
     input_descriptions={
         'distance_matrix': 'Matrix of distances between pairs of samples.'},
     parameter_descriptions={
         **miscellaneous_parameter_descriptions,
         **shared_parameter_descriptions,
+        'baseline': (
+            'Toggle calculation of static distances instead of first '
+            'distances. If a "baseline" value is provided, sample '
+            'distances at each state are compared against the baseline '
+            'state, instead of the previous state. Must be a value listed in '
+            'the state_column that designates a baseline state against which '
+            'all other states should be compared.')
     },
     output_descriptions={'first_distances': 'Series of first distances.'},
-    name='First distance computation between sequential states',
+    name=('Compute first distances or distance from baseline between '
+          'sequential states'),
     description=(
         'Calculates first distances between sequential states for samples '
         'collected from individual subjects sampled repeatedly at two or more '
@@ -310,7 +329,8 @@ plugin.methods.register_function(
         'labeled by the SampleIDs at time 1). This file can be used as input '
         'to linear mixed effects models or other longitudinal or diversity '
         'methods to compare changes in first distances across time or among '
-        'groups of subjects.')
+        'groups of subjects. Also supports distance from baseline (or '
+        'other static comparison state) by setting the "baseline" parameter.')
 )
 
 importlib.import_module('q2_longitudinal._transformer')

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -257,7 +257,7 @@ plugin.methods.register_function(
     parameters={**miscellaneous_parameters,
                 **shared_parameters,
                 'metric': Str,
-                'baseline': Str},
+                'baseline': Float},
     outputs=[('first_differences', SampleData[FirstDifferences])],
     input_descriptions={
         'table': ('Feature table to optionally use for computing first '

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -420,6 +420,38 @@ class TestLongitudinal(TestPluginBase):
             replicate_handling='drop', table=self.table_ecam_fp)
         pdt.assert_series_equal(obs, exp)
 
+    def test_first_differences_baseline(self):
+        exp = pd.Series(
+            [-0.01, 0., 0.01, 0.07, 0.06, 0.09, 0.07, 0.1, 0.15, 0.12, 0.16],
+            index=['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'],
+            name='Difference')
+        exp.index.name = '#SampleID'
+        obs = first_differences(
+            metadata=qiime2.Metadata(md_one_subject_many_times),
+            state_column='Time', individual_id_column='ind',
+            metric='Value', replicate_handling='drop', baseline=0)
+        pdt.assert_series_equal(obs, exp)
+
+    def test_first_differences_baseline_is_not_state_0(self):
+        exp = pd.Series(
+            [-0.01, -0.02, -0.01, 0.06, 0.05, 0.08, 0.06, 0.09, 0.14, 0.11,
+             0.15],
+            index=['0', '1', '2', '4', '5', '6', '7', '8', '9', '10', '11'],
+            name='Difference')
+        exp.index.name = '#SampleID'
+        obs = first_differences(
+            metadata=qiime2.Metadata(md_one_subject_many_times),
+            state_column='Time', individual_id_column='ind',
+            metric='Value', replicate_handling='drop', baseline=3)
+        pdt.assert_series_equal(obs, exp)
+
+    def test_first_differences_baseline_invalid_baseline(self):
+        with self.assertRaisesRegex(ValueError, "must be a valid state"):
+            first_differences(
+                metadata=qiime2.Metadata(md_one_subject_many_times),
+                state_column='Time', individual_id_column='ind',
+                metric='Value', replicate_handling='drop', baseline=27)
+
     def test_first_differences_one_subject_many_times(self):
         exp = pd.Series(
             [-0.01, 0.01, 0.01, 0.06, -0.01, 0.03, -0.02, 0.03, 0.05, -0.03,
@@ -463,6 +495,40 @@ class TestLongitudinal(TestPluginBase):
                 distance_matrix=dm_single_sample, metadata=qiime2.Metadata(md),
                 state_column='Time', individual_id_column='ind',
                 replicate_handling='drop')
+
+    def test_first_distances_baseline(self):
+        exp = pd.Series(
+            [0.3, 1.0, 0.1, 0.1, 0.3, 0.4, 0.5, 0.6, 0.1, 0.2, 0.3],
+            index=['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'],
+            name='Distance')
+        exp.index.name = '#SampleID'
+        obs = first_distances(
+            distance_matrix=dm,
+            metadata=qiime2.Metadata(md_one_subject_many_times),
+            state_column='Time', individual_id_column='ind',
+            replicate_handling='drop', baseline=0)
+        pdt.assert_series_equal(obs, exp)
+
+    def test_first_distances_baseline_is_not_state_0(self):
+        exp = pd.Series(
+            [0.5, 0.6, 0.6, 0.5, 0.4, 0.3, 0.5, 0.8, 0.1, 0.2, 0.3],
+            index=['0', '1', '2', '3', '4', '5', '6', '8', '9', '10', '11'],
+            name='Distance')
+        exp.index.name = '#SampleID'
+        obs = first_distances(
+            distance_matrix=dm,
+            metadata=qiime2.Metadata(md_one_subject_many_times),
+            state_column='Time', individual_id_column='ind',
+            replicate_handling='drop', baseline=7)
+        pdt.assert_series_equal(obs, exp)
+
+    def test_first_distances_baseline_invalid_baseline(self):
+        with self.assertRaisesRegex(ValueError, "must be a valid state"):
+            first_distances(
+                distance_matrix=dm,
+                metadata=qiime2.Metadata(md_one_subject_many_times),
+                state_column='Time', individual_id_column='ind',
+                replicate_handling='drop', baseline=27)
 
     def test_first_distances_one_subject_many_times(self):
         exp = pd.Series(


### PR DESCRIPTION
fixes #68 

I added these as parameters to `first-differences` and `first-distances` instead of adding new methods, because the methods would otherwise be identical.

Is it too confusing to toggle "static distances/differences" with the `baseline` parameter? @gregcaporaso please also advise (you suggested this functionality, originally as a parameter)
