### PR TITLE
tiny PR: move LME results table to top of visualization

### DIFF
--- a/q2_longitudinal/assets/index.html
+++ b/q2_longitudinal/assets/index.html
@@ -28,26 +28,6 @@
 <div class="row">
   <div class="col-lg-12">
     {{ summary }}
-    {% if plot %}
-    <h2>{{ plot_name }}</h1>
-    <div class="text-center">
-      <a href="plot.pdf">
-        <img src="plot.png">
-        <br>
-        <p>Download as PDF</p>
-      </a>
-      {% if raw_data %}
-      <a href="raw-data.tsv">
-        <p>Download raw data as tsv</p>
-      </a>
-      {% endif %}
-      {% if multiple_group_test %}
-      <a href="pairs.tsv">
-        <p>Download within-subject pairwise comparison data as tsv</p>
-      </a>
-      {% endif %}
-    </div>
-    {% endif %}
     {% if model_summary %}
     <h2>Model summary</h1>
     <div class="text-center">
@@ -68,6 +48,26 @@
           <p>Download results as tsv</p>
         </a>
       </div>
+    </div>
+    {% endif %}
+    {% if plot %}
+    <h2>{{ plot_name }}</h1>
+    <div class="text-center">
+      <a href="plot.pdf">
+        <img src="plot.png">
+        <br>
+        <p>Download as PDF</p>
+      </a>
+      {% if raw_data %}
+      <a href="raw-data.tsv">
+        <p>Download raw data as tsv</p>
+      </a>
+      {% endif %}
+      {% if multiple_group_test %}
+      <a href="pairs.tsv">
+        <p>Download within-subject pairwise comparison data as tsv</p>
+      </a>
+      {% endif %}
     </div>
     {% endif %}
     {% if paired_difference_tests %}


### PR DESCRIPTION
fixes #66 

no changes, just shuffled around the html template so the results table appears at the top of the visualization.