### PR TITLE
BUG: volatility: convert single quotes for valid vega spec

### DIFF
--- a/q2_longitudinal/_vega.py
+++ b/q2_longitudinal/_vega.py
@@ -921,5 +921,9 @@ def _render_volatility_spec(data: pd.DataFrame, individual_id: str, state: str,
     rendered_spec = json.dumps(spec)
     rendered_spec = rendered_spec.replace("'", r"\'")
     rendered_data = data.to_json(orient='records')
+    # convert metadata single quotes to unicode
+    rendered_data = rendered_data.replace("'", r'\u0027')
+    rendered_spec = rendered_spec.replace(
+        '"%s"' % DATA_PLACEHOLDER, rendered_data)
 
-    return rendered_spec.replace('"%s"' % DATA_PLACEHOLDER, rendered_data)
+    return rendered_spec

--- a/q2_longitudinal/_vega.py
+++ b/q2_longitudinal/_vega.py
@@ -923,7 +923,4 @@ def _render_volatility_spec(data: pd.DataFrame, individual_id: str, state: str,
     rendered_data = data.to_json(orient='records')
     # convert metadata single quotes to unicode
     rendered_data = rendered_data.replace("'", r'\u0027')
-    rendered_spec = rendered_spec.replace(
-        '"%s"' % DATA_PLACEHOLDER, rendered_data)
-
-    return rendered_spec
+    return rendered_spec.replace('"%s"' % DATA_PLACEHOLDER, rendered_data)


### PR DESCRIPTION
fixes #110 

did not add unit tests because this never raised an error to begin with — just would not display in view.

tried adding json validation (with `json.loads`) to validate the spec... but evidently valid vega specs are ruled invalid by `json.loads`. Any other ideas?
