### PR TITLE
fixed maturity-index test stratification

### DIFF
--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -796,7 +796,7 @@ class TestLongitudinal(TestPluginBase):
         res = longitudinal.actions.maturity_index(
             table, self.md_ecam_fp, state_column='month', n_estimators=2,
             group_by='delivery', random_state=123, n_jobs=1, control='Vaginal',
-            test_size=0.4, missing_samples='ignore')
+            test_size=0.4, missing_samples='ignore', stratify=True)
         maz = pd.to_numeric(res[5].view(pd.Series))
         exp_maz = pd.read_csv(
             self.get_data_path('maz.tsv'), sep='\t', squeeze=True, index_col=0,


### PR DESCRIPTION
[This](https://github.com/qiime2/q2-sample-classifier/commit/29d2d0a05d3c4e4a5c6277de64dc7f57b57f91ec) bug fix impacted the default stratification behavior of maturity-index. That parameter is now set explicitly in the unit tests.