### PR TITLE
ENH: added feature count limit for maturity heatmaps

### DIFF
--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -9,7 +9,7 @@
 import importlib
 
 from qiime2.plugin import (Str, Bool, Plugin, Metadata, Choices, Range, Float,
-                           Citations, Visualization)
+                           Int, Citations, Visualization)
 from q2_types.feature_table import FeatureTable, RelativeFrequency, Frequency
 from q2_types.distance_matrix import DistanceMatrix
 from q2_types.sample_data import SampleData
@@ -521,6 +521,7 @@ plugin.pipelines.register_function(
                 'metadata': Metadata,
                 'state_column': Str,
                 'stratify': Bool,
+                'feature_count': Int % Range(0, None)
                 },
     outputs=regressor_pipeline_outputs + [
         ('maz_scores', SampleData[RegressorPredictions]),
@@ -546,7 +547,10 @@ plugin.pipelines.register_function(
         'estimator': 'Regression model to use for prediction.',
         'stratify': 'Evenly stratify training and test data among metadata '
                     'categories. If True, all values in column must match '
-                    'at least two samples.'},
+                    'at least two samples.',
+        'feature_count': 'Filter feature table to include top N most '
+                         'important features. Set to zero to include all '
+                         'features.'},
     output_descriptions={
         **pipeline_output_descriptions,
         'maz_scores': 'Microbiota-for-age z-score predictions.',

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -906,7 +906,8 @@ class TestLongitudinal(TestPluginBase):
         res = longitudinal.actions.maturity_index(
             table, self.md_ecam_fp, state_column='month', n_estimators=2,
             group_by='delivery', random_state=123, n_jobs=1, control='Vaginal',
-            test_size=0.4, missing_samples='ignore', stratify=True)
+            test_size=0.4, missing_samples='ignore', stratify=True,
+            feature_count=10)
         maz = pd.to_numeric(res[5].view(pd.Series))
         exp_maz = pd.read_csv(
             self.get_data_path('maz.tsv'), sep='\t', squeeze=True, index_col=0,


### PR DESCRIPTION
the `maturity_index` heatmaps are too slow! In part because the heatmaps contain all important features.

I have added a parameter for limiting the number of features displayed in that heatmap. This will speed up execution and ease interpretation. Related to [this](https://github.com/qiime2/q2-sample-classifier/pull/147) but unfortunately cannot wrap that action here since the `maturity_index` heatmap has very specific requirements.

partial fix for #126 
