### PR TITLE
adding importance filtering to feature_volatility

### DIFF
--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -26,7 +26,7 @@ from ._utilities import (_get_group_pairs, _extract_distance_distribution,
                          _regplot_subplots_from_dataframe, _load_metadata,
                          _validate_input_values, _validate_input_columns,
                          _nmit, _validate_is_numeric_column, _maz_score,
-                         _first_differences,
+                         _first_differences, _importance_filtering,
                          _summarize_feature_stats, _convert_nan_to_none,
                          _parse_formula, _visualize_anova)
 from ._vega_specs import render_spec_volatility
@@ -409,9 +409,22 @@ def plot_feature_volatility(output_dir: str,
                             state_column: str,
                             individual_id_column: str = None,
                             default_group_column: str = None,
-                            yscale: str = 'linear') -> None:
+                            yscale: str = 'linear',
+                            importance_threshold: float = None,
+                            feature_count: int = 100,
+                            missing_samples: str = 'error') -> None:
+    # validate importances index is superset of table columns
+    if missing_samples == 'error':
+        _validate_metadata_is_superset(importances, table.T)
+
+    # filter table, importances based on importance threshold / feature count
+    if importance_threshold is not None and feature_count is not None:
+        table, importances = _importance_filtering(
+            table, importances, importance_threshold, feature_count)
+
     # default_metric should be whatever the most important feature is
     default_metric = importances.index[0]
+
     _volatility(output_dir, metadata, state_column, individual_id_column,
                 default_group_column, default_metric, table, yscale,
                 importances)
@@ -614,7 +627,9 @@ def feature_volatility(ctx,
                        n_estimators=100,
                        estimator='RandomForestRegressor',
                        parameter_tuning=False,
-                       missing_samples='error'):
+                       missing_samples='error',
+                       importance_threshold=None,
+                       feature_count=100):
     regress = ctx.get_action('sample_classifier', 'regress_samples')
     # TODO: Add this back once filter_features can operate on a
     # FeatureTable[RelativeFrequency] artifact (see notes below)
@@ -657,6 +672,9 @@ def feature_volatility(ctx,
                                   state_column=state_column,
                                   individual_id_column=individual_id_column,
                                   default_group_column=None,
-                                  yscale='linear')
+                                  yscale='linear',
+                                  importance_threshold=importance_threshold,
+                                  feature_count=feature_count,
+                                  missing_samples='ignore')
 
     return filtered_table, importances, volatility_plot, accuracy, estimator

--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -418,9 +418,8 @@ def plot_feature_volatility(output_dir: str,
         _validate_metadata_is_superset(importances, table.T)
 
     # filter table, importances based on importance threshold / feature count
-    if importance_threshold is not None or feature_count is not None:
-        table, importances = _importance_filtering(
-            table, importances, importance_threshold, feature_count)
+    table, importances = _importance_filtering(
+        table, importances, importance_threshold, feature_count)
 
     # default_metric should be whatever the most important feature is
     default_metric = importances.index[0]

--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -418,7 +418,7 @@ def plot_feature_volatility(output_dir: str,
         _validate_metadata_is_superset(importances, table.T)
 
     # filter table, importances based on importance threshold / feature count
-    if importance_threshold is not None and feature_count is not None:
+    if importance_threshold is not None or feature_count is not None:
         table, importances = _importance_filtering(
             table, importances, importance_threshold, feature_count)
 

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -897,15 +897,19 @@ def _importance_filtering(table, importances, importance_threshold,
     if importance_threshold in ['q1', 'q2', 'q3']:
         importance_threshold = importances.quantile(
             quantiles[importance_threshold])
-    if importance_threshold == 'None':
+
+    if importance_threshold is None:
         pass
     elif importance_threshold > 0:
         importances = importances[importances >= importance_threshold]
         filtered = True
+
     if feature_count != 'all':
         importances = importances[:feature_count]
         filtered = True
+
     # if any importance filtering occurred, subset table features
     if filtered:
         table = table[importances.index]
+
     return table, importances

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -898,10 +898,10 @@ def _importance_filtering(table, importances, importance_threshold,
     if importance_threshold in ['q1', 'q2', 'q3']:
         importance_threshold = importances.quantile(
             quantiles[importance_threshold])
+    elif importance_threshold is None:
+        importance_threshold = 0.0
 
-    if importance_threshold is None:
-        pass
-    elif importance_threshold > 0:
+    if importance_threshold > 0:
         importances = importances[importances >= importance_threshold]
         filtered = True
 

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -891,6 +891,7 @@ def _importance_filtering(table, importances, importance_threshold,
     # avg importances by rows (to take average if there are multiple scores).
     importances = importances.mean(1)
     importances = importances.sort_values(ascending=False)
+    importances.name = 'importance'
 
     filtered = False
     # filter importances by user criteria
@@ -912,4 +913,4 @@ def _importance_filtering(table, importances, importance_threshold,
     if filtered:
         table = table[importances.index]
 
-    return table, importances
+    return table, importances.to_frame()

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -871,3 +871,41 @@ def _dodge_patsy_errors(metadata, metric):
         metadata[metric] = metadata[old_metric]
 
     return metadata, metric, old_metric
+
+
+def _importance_filtering(table, importances, importance_threshold,
+                          feature_count):
+    '''
+    Filter feature table based on importance scores and thresholds.
+
+    table: pd.DataFrame
+        Feature table.
+    importances: pd.DataFrame
+        Importance scores for each feature.
+    importance_threshold: float or str % Choices(['q1', 'q2', 'q3']) or None
+        Importance filtering threshold
+    feature_count: int or None
+        Number of top features to retain
+    '''
+    quantiles = {'q1': 0.25, 'q2': 0.5, 'q3': 0.75}
+    # avg importances by rows (to take average if there are multiple scores).
+    importances = importances.mean(1)
+    importances = importances.sort_values(ascending=False)
+
+    filtered = False
+    # filter importances by user criteria
+    if importance_threshold in ['q1', 'q2', 'q3']:
+        importance_threshold = importances.quantile(
+            quantiles[importance_threshold])
+    if importance_threshold == 'None':
+        pass
+    elif importance_threshold > 0:
+        importances = importances[importances >= importance_threshold]
+        filtered = True
+    if feature_count != 'all':
+        importances = importances[:feature_count]
+        filtered = True
+    # if any importance filtering occurred, subset table features
+    if filtered:
+        table = table[importances.index]
+    return table, importances

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -132,7 +132,7 @@ paired_parameter_descriptions = {
 volatility_filtering_parameters = {
     'feature_count': Int % Range(1, None) | Str % Choices(['all']),
     'importance_threshold': (Float % Range(0, None, inclusive_start=False) |
-                             Str % Choices(['q1', 'q2', 'q3', 'None']))}
+                             Str % Choices(['q1', 'q2', 'q3']))}
 
 volatility_filtering_parameter_descriptions = {
     'feature_count': 'Filter feature table to include top N most '

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -172,36 +172,37 @@ class TestImportanceFiltering(TestPluginBase):
         super().setUp()
 
         self.imp = pd.DataFrame([6., 5., 4., 3., 2., 1.],
-                                index=[i for i in 'abcdef'])
+                                index=[i for i in 'abcdef'],
+                                columns=['importance'])
         self.tab = pd.DataFrame([[1., 2., 3., 4., 5., 6.]] * 4,
                                 index=[s for s in 'vxyz'],
                                 columns=[i for i in 'abcdef'])
 
     def test_importance_filtering_none(self):
         tab, imps = _importance_filtering(
-            self.tab, self.imp, importance_threshold='None',
+            self.tab, self.imp, importance_threshold=None,
             feature_count='all')
         pdt.assert_frame_equal(self.tab, tab)
-        pdt.assert_frame_equal(self.imp, imps.to_frame())
+        pdt.assert_frame_equal(self.imp, imps)
 
     def test_importance_filtering_count(self):
         tab, imps = _importance_filtering(
-            self.tab, self.imp, importance_threshold='None',
+            self.tab, self.imp, importance_threshold=None,
             feature_count=3)
         pdt.assert_frame_equal(self.tab[['a', 'b', 'c']], tab)
-        pdt.assert_frame_equal(self.imp[:3], imps.to_frame())
+        pdt.assert_frame_equal(self.imp[:3], imps)
 
     def test_importance_float_threshold(self):
         tab, imps = _importance_filtering(
             self.tab, self.imp, importance_threshold=5., feature_count=10)
         pdt.assert_frame_equal(self.tab[['a', 'b']], tab)
-        pdt.assert_frame_equal(self.imp[:2], imps.to_frame())
+        pdt.assert_frame_equal(self.imp[:2], imps)
 
     def test_importance_quartile_threshold(self):
         tab, imps = _importance_filtering(
             self.tab, self.imp, importance_threshold='q2', feature_count='all')
         pdt.assert_frame_equal(self.tab[['a', 'b', 'c']], tab)
-        pdt.assert_frame_equal(self.imp[:3], imps.to_frame())
+        pdt.assert_frame_equal(self.imp[:3], imps)
 
 
 class TestParseFormula(TestPluginBase):

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -27,7 +27,8 @@ from q2_longitudinal._utilities import (
     _multiple_group_difference, _per_method_pairwise_stats,
     _multiple_tests_correction, _add_sample_size_to_xtick_labels,
     _temporal_corr, _temporal_distance, _nmit, _validate_is_numeric_column,
-    _validate_metadata_is_superset, _summarize_feature_stats, _parse_formula)
+    _validate_metadata_is_superset, _summarize_feature_stats, _parse_formula,
+    _importance_filtering)
 from q2_longitudinal._longitudinal import (
     pairwise_differences, pairwise_distances, linear_mixed_effects, volatility,
     nmit, first_differences, first_distances, plot_feature_volatility, anova)
@@ -162,6 +163,45 @@ class TestUtilities(TestPluginBase):
         erroneous_metadata = pd.DataFrame({'a': [1, 2, 'b']})
         with self.assertRaisesRegex(ValueError, "is not a numeric"):
             _validate_is_numeric_column(erroneous_metadata, 'a')
+
+
+class TestImportanceFiltering(TestPluginBase):
+    package = 'q2_longitudinal.tests'
+
+    def setUp(self):
+        super().setUp()
+
+        self.imp = pd.DataFrame([6., 5., 4., 3., 2., 1.],
+                                index=[i for i in 'abcdef'])
+        self.tab = pd.DataFrame([[1., 2., 3., 4., 5., 6.]] * 4,
+                                index=[s for s in 'vxyz'],
+                                columns=[i for i in 'abcdef'])
+
+    def test_importance_filtering_none(self):
+        tab, imps = _importance_filtering(
+            self.tab, self.imp, importance_threshold='None',
+            feature_count='all')
+        pdt.assert_frame_equal(self.tab, tab)
+        pdt.assert_frame_equal(self.imp, imps.to_frame())
+
+    def test_importance_filtering_count(self):
+        tab, imps = _importance_filtering(
+            self.tab, self.imp, importance_threshold='None',
+            feature_count=3)
+        pdt.assert_frame_equal(self.tab[['a', 'b', 'c']], tab)
+        pdt.assert_frame_equal(self.imp[:3], imps.to_frame())
+
+    def test_importance_float_threshold(self):
+        tab, imps = _importance_filtering(
+            self.tab, self.imp, importance_threshold=5., feature_count=10)
+        pdt.assert_frame_equal(self.tab[['a', 'b']], tab)
+        pdt.assert_frame_equal(self.imp[:2], imps.to_frame())
+
+    def test_importance_quartile_threshold(self):
+        tab, imps = _importance_filtering(
+            self.tab, self.imp, importance_threshold='q2', feature_count='all')
+        pdt.assert_frame_equal(self.tab[['a', 'b', 'c']], tab)
+        pdt.assert_frame_equal(self.imp[:3], imps.to_frame())
 
 
 class TestParseFormula(TestPluginBase):


### PR DESCRIPTION
fixes #144 

This PR:
1. Adds a new utility function for filtering a table based on importance scores, quartiles, or feature counts. This function is used in `plot_feature_volatility` and exposed in that action as well as its parent pipeline, `feature_volatility`. Default is to filter 100 most important features, so this should fix the problems described in #144.
2. Adds new unit tests for utility described in item 1.
3. Adds param `missing_samples` to error or ignore missing samples in `plot_feature_volatility`. (this is not in response to an issue nor is it necessarily a bug — this action is usually run as part of a pipeline where this will not be an issue — just being proactive).