### PR TITLE
MAINT: Update copyright headers to 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017-2019, QIIME 2 development team.
+Copyright (c) 2017-2020, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/q2_longitudinal/__init__.py
+++ b/q2_longitudinal/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_format.py
+++ b/q2_longitudinal/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_transformer.py
+++ b/q2_longitudinal/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_type.py
+++ b/q2_longitudinal/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/__init__.py
+++ b/q2_longitudinal/_vega_specs/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/__init__.py
+++ b/q2_longitudinal/_vega_specs/volatility/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/axis.py
+++ b/q2_longitudinal/_vega_specs/volatility/axis.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/const.py
+++ b/q2_longitudinal/_vega_specs/volatility/const.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/data.py
+++ b/q2_longitudinal/_vega_specs/volatility/data.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/legend.py
+++ b/q2_longitudinal/_vega_specs/volatility/legend.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/mark.py
+++ b/q2_longitudinal/_vega_specs/volatility/mark.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/render.py
+++ b/q2_longitudinal/_vega_specs/volatility/render.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/scale.py
+++ b/q2_longitudinal/_vega_specs/volatility/scale.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/_vega_specs/volatility/signal.py
+++ b/q2_longitudinal/_vega_specs/volatility/signal.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/assets/volatility/css/spinkit.css
+++ b/q2_longitudinal/assets/volatility/css/spinkit.css
@@ -1,7 +1,7 @@
 /* SPINKIT */
 /*
 The MIT License (MIT)
-Copyright (c) 2015-2019 Tobias Ahlin
+Copyright (c) 2015-2020 Tobias Ahlin
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to

--- a/q2_longitudinal/assets/volatility/licenses/vega-embed.txt
+++ b/q2_longitudinal/assets/volatility/licenses/vega-embed.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2019, University of Washington Interactive Data Lab
+Copyright (c) 2015-2020, University of Washington Interactive Data Lab
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/q2_longitudinal/assets/volatility/licenses/vega.txt
+++ b/q2_longitudinal/assets/volatility/licenses/vega.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2019, University of Washington Interactive Data Lab
+Copyright (c) 2015-2020, University of Washington Interactive Data Lab
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/tests/__init__.py
+++ b/q2_longitudinal/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/tests/test_format.py
+++ b/q2_longitudinal/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/tests/test_transformer.py
+++ b/q2_longitudinal/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_longitudinal/tests/test_type.py
+++ b/q2_longitudinal/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, QIIME 2 development team.
+# Copyright (c) 2017-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
Update copyright headers to reflect current year.
