### PR TITLE
Fixed "truncate=False" parameter

### DIFF
--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -415,7 +415,7 @@ def _regplot_subplots_from_dataframe(state_column, metric, metadata,
         for name, group_data in metadata.groupby(group_column):
             sns.regplot(state_column, metric, data=group_data, fit_reg=fit_reg,
                         scatter_kws={"marker": ".", "s": 100}, label=name,
-                        ax=ax, lowess=lowess, ci=ci)
+                        ax=ax, lowess=lowess, ci=ci, truncate=False)
         ax.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
     return f
 


### PR DESCRIPTION
Fixed "truncate=False" parameter in _regplot_subplots_from_dataframe() function:
            "sns.regplot(state_column, metric, data=group_data, fit_reg=fit_reg,
                        scatter_kws={"marker": ".", "s": 100}, label=name,
                        ax=ax, lowess=lowess, ci=ci, truncate=False)"
Link to the issue: https://forum.qiime2.org/t/lme-visualizations/16393

Brief summary of the Pull Request, including any issues it may fix using the GitHub closing syntax:

https://help.github.com/articles/closing-issues-using-keywords/

Also, include any co-authors or contributors using the GitHub coauthor tag:

https://help.github.com/articles/creating-a-commit-with-multiple-authors/

---

Include any questions for reviewers, screenshots, sample outputs, etc.
