### PR TITLE
bug: close figs _all_ the time

### DIFF
--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -500,7 +500,7 @@ def _visualize(output_dir, multiple_group_test=False, pairwise_tests=False,
             os.path.join(output_dir, 'residuals.png'), bbox_inches='tight')
         residuals.savefig(
             os.path.join(output_dir, 'residuals.pdf'), bbox_inches='tight')
-        plt.close('all')
+    plt.close('all')
 
     index = os.path.join(TEMPLATES, 'index.html')
     q2templates.render(index, output_dir, context={


### PR DESCRIPTION
fixes a longstanding bug introduced 3 years ago, in #99. This is mostly an issue when running the unittests - the mpl canvas doesn't get cleared in some cases, which causes all kinds of downstream errors when trying to do things like set axis labels, etc.